### PR TITLE
fix: adjust sendbird syncmanager typings

### DIFF
--- a/SendBirdSyncManager.d.ts
+++ b/SendBirdSyncManager.d.ts
@@ -8,6 +8,7 @@ type Message = UserMessage | FileMessage | AdminMessage;
 
 export { SendBirdSyncManager, ChannelCollection, MessageCollection };
 export as namespace SendBirdSyncManager;
+export = SendBirdSyncManager;
 
 declare const SendBirdSyncManager: SendBirdSyncManagerStatic;
 declare const ChannelCollection: ChannelCollectionStatic;


### PR DESCRIPTION
When using typescript, the basic [example](https://docs.sendbird.com/javascript/sync_manager_getting_started) to get started with Sync Manager does not work.  

I was able to run the same code using plain JS, but with typescript, the typing causes a runtime issue.  My redux-saga silently fails due to a TypeError exception.  

`TypeError: Cannot read property ‘Options’ of undefined at ...`

With a bit of research, I noticed we have a PR (#3) that is a bit outdated and does seem to work.  I found that the default export was not properly typed.

Tested on:
Typescript 3.x
React 16.x
SendBird 3.0.145
SyncManager 1.1.20

https://community.sendbird.com/t/syncmanager-not-working/1142